### PR TITLE
Fix for CurrentCulture="ru-RU" & Create NativeOsMessageBox.ShowExceptionDialogAsync

### DIFF
--- a/AvaloniaMessageBox/CulturePrompt.cs
+++ b/AvaloniaMessageBox/CulturePrompt.cs
@@ -47,7 +47,6 @@ namespace CastelloBranco.AvaloniaMessageBox;
             new("it", "Sì", "No", "Ok", "Annulla", "Eccezione", "Si è verificato un errore", "Posizione", "Messaggio"),
             new("ja", "はい", "いいえ", "OK", "キャンセル", "例外", "エラーが発生しました", "場所", "メッセージ"),
             new("zh-CN", "是", "否", "确定", "取消", "异常", "发生了一个错误", "位置", "消息"),
-            new("ru", "Да", "Нет", "ОК", "Отмена", "Исключение", "Произошла ошибка", "Местоположение", "Сообщение"),
             new("ko", "예", "아니오", "확인", "취소", "예외", "오류가 발생했습니다", "위치", "메시지"),
             new("ar", "نعم", "لا", "موافق", "إلغاء", "استثناء", "حدث خطأ", "الموقع", "الرسالة"),
             new("en-US", "Yes", "No", "OK", "Cancel", "Exception", "An error occurred", "Location", "Message"),

--- a/AvaloniaMessageBox/ExceptionHelper.cs
+++ b/AvaloniaMessageBox/ExceptionHelper.cs
@@ -1,0 +1,48 @@
+﻿using System.Diagnostics;
+using System.Text;
+
+namespace CastelloBranco.AvaloniaMessageBox;
+
+internal static class ExceptionHelper
+{
+    public static string ProvideExceptionDescription(Exception ex)
+    {
+        string exceptionName = ex.GetType().Name;
+        string exceptionMessage = ex.Message;
+
+        string? fileName = null;
+        int? lineNumber = null;
+
+        try
+        {
+            StackTrace st = new (ex, true);
+            
+            StackFrame? firstFrame = st.GetFrames()?.FirstOrDefault(f =>
+                !string.IsNullOrWhiteSpace(f.GetFileName()) &&
+                f.GetFileLineNumber() > 0);
+
+            if (firstFrame != null)
+            {
+                fileName = firstFrame.GetFileName();
+                lineNumber = firstFrame.GetFileLineNumber();
+            }
+        }
+        catch
+        {
+            // Ignore reflection or debug info errors
+        }
+
+        var cp = CulturePrompt.Current; 
+
+        var sb = new StringBuilder();
+        
+        sb.AppendLine($"{cp.Exception}: {exceptionName}");
+        
+        if (!string.IsNullOrWhiteSpace(fileName) && lineNumber.HasValue)
+            sb.AppendLine($"{cp.Location}: {System.IO.Path.GetFileName(fileName)}:{lineNumber}");
+
+        sb.AppendLine($"{cp.Message}: {exceptionMessage}");
+
+        return sb.ToString().Trim();
+    }
+}

--- a/AvaloniaMessageBox/ExceptionMessageBox.cs
+++ b/AvaloniaMessageBox/ExceptionMessageBox.cs
@@ -8,46 +8,13 @@ public static class ExceptionMessageBox
 {
     public static async Task ShowExceptionDialogAsync(object? parent, Exception ex)
     {
-        string exceptionName = ex.GetType().Name;
-        string exceptionMessage = ex.Message;
-
-        string? fileName = null;
-        int? lineNumber = null;
-
-        try
-        {
-            StackTrace st = new (ex, true);
-            
-            StackFrame? firstFrame = st.GetFrames()?.FirstOrDefault(f =>
-                !string.IsNullOrWhiteSpace(f.GetFileName()) &&
-                f.GetFileLineNumber() > 0);
-
-            if (firstFrame != null)
-            {
-                fileName = firstFrame.GetFileName();
-                lineNumber = firstFrame.GetFileLineNumber();
-            }
-        }
-        catch
-        {
-            // Ignore reflection or debug info errors
-        }
-
-        var cp = CulturePrompt.Current; 
-
-        var sb = new StringBuilder();
-        
-        sb.AppendLine($"{cp.Exception}: {exceptionName}");
-        
-        if (!string.IsNullOrWhiteSpace(fileName) && lineNumber.HasValue)
-            sb.AppendLine($"{cp.Location}: {System.IO.Path.GetFileName(fileName)}:{lineNumber}");
-
-        sb.AppendLine($"{cp.Message}: {exceptionMessage}");
+        var text = ExceptionHelper.ProvideExceptionDescription(ex);
+        var caption = CulturePrompt.Current.AnErrorWasOcurred;
 
         await MessageBox.ShowAsync(
             parent,
-            cp.AnErrorWasOcurred,
-            sb.ToString().Trim(),
+            caption,
+            text,
             MessageBoxButtons.Ok,
             MessageBoxIcon.Stop
         );

--- a/AvaloniaMessageBox/NativeOsMessageBox.cs
+++ b/AvaloniaMessageBox/NativeOsMessageBox.cs
@@ -34,6 +34,27 @@ public static class NativeOsMessageBox
             throw new NotSupportedException("Avalonia not available and Native Os not supported." );
         }
     }
+    
+    public static async Task<MessageBoxResult> ShowExceptionDialogAsync(Exception ex)
+    {
+        var text = ExceptionHelper.ProvideExceptionDescription(ex);
+        var caption = CulturePrompt.Current.AnErrorWasOcurred;
+        
+        if (OperatingSystem.IsMacOS())
+        {
+            return await NativeMessageBoxMacOs.ShowAsync(caption, text, MessageBoxButtons.Ok, MessageBoxIcon.Stop);
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            return NativeMessageBoxLinuxX11.Show(caption, text, MessageBoxButtons.Ok, MessageBoxIcon.Stop);
+        }
+        else if (OperatingSystem.IsWindows())
+        {
+            return await NativeMessageBoxWindows.ShowAsync(caption, text, MessageBoxButtons.Ok, MessageBoxIcon.Stop);
+        }
+        else
+        {
+            throw new NotSupportedException("Avalonia not available and Native Os not supported.");
+        }
+    }
 }
-
-


### PR DESCRIPTION
This PR fixes error on getting CulturePrompt.Current when CurrentCulture is ru-RU and introduces method NativeOsMessageBox.cs.ShowExceptionDialogAsync (something like ExceptionMessageBox.ShowExceptionDialogAsync, but using only OS native api's)